### PR TITLE
Customized message on Todos for first timers

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -84,6 +84,7 @@ const User = require('../models/User')
       userName: req.body.userName,
       email: req.body.email,
       password: req.body.password
+      //a first time sign up does not have a lastActiveDate key. use to differentiate summary on getTodos
     })
   
     User.findOne({$or: [

--- a/views/todos.ejs
+++ b/views/todos.ejs
@@ -10,10 +10,16 @@
 <body>
     <h1>Todos</h1>
 
-    <h2>Welcome <%= user.userName %>!</h2>
+    <% if (lastActiveDate) { %>
+        <h2>Welcome back, <%= user.userName %>!</h2>
+    <% } else { %>   
+        <h2>Welcome, <%= user.userName %>!</h2>
+    <% } %>
     <p>Today is <%= new Date();%>.</p>
+    <% if (lastActiveDate) { %>
     <p>You last logged in on <%= lastActiveDate %>.</p>
-    
+    <% } %>
+
     <ul>
     <% todos.forEach( el => { %>
             <li class='todoItem' data-id='<%=el._id%>'>


### PR DESCRIPTION
Updated the previously awkward greeting on the **Todos** page for new users seeing it for the first time.
This builds on the last edit that creates a lastActiveDate tracker for the user on login.

## Approach
First-timers (brand new user, just signed in) do not have the 'lastActiveDate' key nor truthy (that is, not zero/null/undefined/"falsy") value for it. 
- in **views/Todos.ejs** we use lastActiveDate variable to make a conditional. If lastActiveDate is nonexistent, use the text "Welcome, [username]!" and omit the "You last logged in..." statement.
- Else, show "Welcome back, [username]!" and the previous activity mention.

## Before

New user, first time seeing Todos page:
![sessionRef_BEFORE-newsignup](https://user-images.githubusercontent.com/102257735/188252945-ccbd6775-f5d0-4929-9484-b5517d33836c.png)

Old user, logging back in:
![sessionRef_BEFORE-logbackin](https://user-images.githubusercontent.com/102257735/188252935-dab20269-0fe1-4536-bf2e-44843808324b.png)


## After
New user, first time seeing Todos page:
![sessionRef_AFTER_first time after signup](https://user-images.githubusercontent.com/102257735/188252952-e1cd10c7-957c-47e4-abb8-066d9e2400b2.png)

Old user, logging back in:
![sessionRef_AFTER_logging back in](https://user-images.githubusercontent.com/102257735/188252958-9a947453-1eee-42d2-81a6-d32be1c423d7.png)
